### PR TITLE
fixed bug when '///' missing in multiline comment

### DIFF
--- a/src/SourceBrowser.Generator/DocumentWalker.cs
+++ b/src/SourceBrowser.Generator/DocumentWalker.cs
@@ -64,7 +64,7 @@ namespace SourceBrowser.Generator
                 trivia.CSharpKind() == SyntaxKind.SingleLineDocumentationCommentTrivia)
             {
                 htmlTrivia += "<span style='color:green'>";
-                htmlTrivia += HttpUtility.HtmlEncode(trivia.ToString());
+                htmlTrivia += HttpUtility.HtmlEncode(trivia.ToFullString());
                 htmlTrivia += "</span>";
             }
             else if (trivia.CSharpKind() == SyntaxKind.RegionDirectiveTrivia ||


### PR DESCRIPTION
Fixes #6 

Replaced ToString() with ToFullString() also on comments since the first '///' are
considered as leading trivia and not included in ToString()
