### PR TITLE
Fix: Sample project was unable to save

### DIFF
--- a/src/SourceBrowser.Samples/Program.cs
+++ b/src/SourceBrowser.Samples/Program.cs
@@ -38,7 +38,7 @@ namespace SourceBrowser.Samples
                 Console.Write("Analyzing and saving into " + absoluteSaveDirectory);
                 Console.WriteLine("...");
 
-                solutionAnalyzer.AnalyzeAndSave(saveDirectory);
+                solutionAnalyzer.AnalyzeAndSave(absoluteSaveDirectory);
 
                 Console.WriteLine("Job successful!");
             }


### PR DESCRIPTION
Because the provided path was the wrong variable (it was a relative path, should be an absolute one)
