### PR TITLE
Fixes #63 and miscellaneous bugs.

### DIFF
--- a/src/SourceBrowser.Generator/DocumentWalkers/CSWalker.cs
+++ b/src/SourceBrowser.Generator/DocumentWalkers/CSWalker.cs
@@ -168,16 +168,23 @@ namespace SourceBrowser.Generator.DocumentWalkers
 
         private string GetSymbolName(ISymbol symbol)
         {
-            if (symbol.Kind == SymbolKind.Parameter || symbol.Kind == SymbolKind.Local)
+            string fullyQualifiedName;
+            if (symbol.Kind == SymbolKind.Parameter) 
             {
                 var containingName = symbol.ContainingSymbol.ToString();
-                var name = containingName + "::" + symbol.Name;
-                return name;
+                fullyQualifiedName = containingName + CSharpDelimiters.PARAMETER + symbol.Name;
+            }
+            else if (symbol.Kind == SymbolKind.Local) 
+            {
+                var containingName = symbol.ContainingSymbol.ToString();
+                fullyQualifiedName = containingName + CSharpDelimiters.LOCAL_VARIABLE + symbol.Name;
             }
             else
             {
-                return symbol.ToString();
+                fullyQualifiedName = symbol.ToString();
             }
+
+            return fullyQualifiedName;
         }
 
         public Token ProcessIdentifier(SyntaxToken token)

--- a/src/SourceBrowser.Generator/DocumentWalkers/VBWalker.cs
+++ b/src/SourceBrowser.Generator/DocumentWalkers/VBWalker.cs
@@ -168,16 +168,23 @@ namespace SourceBrowser.Generator.DocumentWalkers
 
         private string GetSymbolName(ISymbol symbol)
         {
-            if (symbol.Kind == SymbolKind.Parameter || symbol.Kind == SymbolKind.Local)
+            string fullyQualifiedName;
+            if (symbol.Kind == SymbolKind.Parameter)
             {
                 var containingName = symbol.ContainingSymbol.ToString();
-                var name = containingName + "::" + symbol.Name;
-                return name;
+                fullyQualifiedName = containingName + VBDelimiters.PARAMETER + symbol.Name;
+            }
+            else if (symbol.Kind == SymbolKind.Local)
+            {
+                var containingName = symbol.ContainingSymbol.ToString();
+                fullyQualifiedName = containingName + VBDelimiters.LOCAL_VARIABLE + symbol.Name;
             }
             else
             {
-                return symbol.ToString();
+                fullyQualifiedName = symbol.ToString();
             }
+
+            return fullyQualifiedName;
         }
 
         public Token ProcessIdentifier(SyntaxToken token)

--- a/src/SourceBrowser.Generator/DocumentWalkers/VBWalker.cs
+++ b/src/SourceBrowser.Generator/DocumentWalkers/VBWalker.cs
@@ -10,6 +10,8 @@ using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SourceBrowser.Generator.Extensions;
 using SourceBrowser.Generator.Model;
 using SourceBrowser.Generator.Model.VisualBasic;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.FindSymbols;
 
 namespace SourceBrowser.Generator.DocumentWalkers
 {
@@ -23,7 +25,9 @@ namespace SourceBrowser.Generator.DocumentWalkers
         public DocumentModel DocumentModel { get; private set; }
         public string FilePath { get; set; }
 
-        public VBWalker(IProjectItem parent, Document document, ReferencesourceLinkProvider refSourceLinkProvider): base(SyntaxWalkerDepth.Trivia)
+        private Document _document;
+
+        public VBWalker(IProjectItem parent, Document document, ReferencesourceLinkProvider refSourceLinkProvider) : base(SyntaxWalkerDepth.Trivia)
         {
             _model = document.GetSemanticModelAsync().Result;
             _refsourceLinkProvider = refSourceLinkProvider;
@@ -33,12 +37,13 @@ namespace SourceBrowser.Generator.DocumentWalkers
             DocumentModel = new DocumentModel(parent, document.Name, numberOfLines);
             FilePath = document.GetRelativeFilePath();
             _refsourceLinkProvider = refSourceLinkProvider;
+            _document = document;
         }
 
         public override void VisitToken(SyntaxToken token)
         {
             Token tokenModel = null;
-          
+
             if (token.IsKeyword())
             {
                 tokenModel = ProcessKeyword(token);
@@ -47,7 +52,7 @@ namespace SourceBrowser.Generator.DocumentWalkers
             {
                 tokenModel = ProcessIdentifier(token);
             }
-            else if(token.VisualBasicKind() == SyntaxKind.StringLiteralToken)
+            else if (token.VisualBasicKind() == SyntaxKind.StringLiteralToken)
             {
                 tokenModel = ProcessStringLiteral(token);
             }
@@ -92,7 +97,6 @@ namespace SourceBrowser.Generator.DocumentWalkers
             int lineNumber = token.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
 
             var tokenModel = new Token(this.DocumentModel, fullName, value, type, lineNumber);
-
             return tokenModel;
         }
 
@@ -105,7 +109,6 @@ namespace SourceBrowser.Generator.DocumentWalkers
             string value = token.ToString();
             string type = VisualBasicTokenTypes.KEYWORD;
             int lineNumber = token.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-
             var tokenModel = new Token(this.DocumentModel, fullName, value, type, lineNumber);
             return tokenModel;
         }
@@ -116,46 +119,18 @@ namespace SourceBrowser.Generator.DocumentWalkers
             string value = token.ToString();
             string type = VisualBasicTokenTypes.STRING;
             int lineNumber = token.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-
             var tokenModel = new Token(this.DocumentModel, fullName, value, type, lineNumber);
             return tokenModel;
         }
 
-        /// <summary>
-        /// Given a syntax token identifier that represents a declaration,
-        /// generate and return the proper HTML for this symbol.
-        /// </summary>
-        public Token ProcessDeclarationToken(SyntaxToken token, ISymbol parentSymbol)
+        public Token ProcessSymbolUsage(SyntaxToken token, ISymbol symbol, bool isDeclaration)
         {
-            string fullName = parentSymbol.ToString();
+            string fullName = GetSymbolName(symbol);
             string value = token.ToString();
-            string type = string.Empty;
+            string type = String.Empty;
             int lineNumber = token.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-            bool isDeclaration = true;
+            bool isSearchable = isDeclaration;
 
-            if (parentSymbol is INamedTypeSymbol)
-            {
-                type = VisualBasicTokenTypes.TYPE;
-            }
-            else
-            {
-                type = VisualBasicTokenTypes.IDENTIFIER;
-            }
-
-            var tokenModel = new Token(this.DocumentModel, fullName, value, type, lineNumber, isDeclaration);
-            return tokenModel;
-        }
-
-        /// <summary>
-        /// Given a syntax token identifier that represents a symbol's usage
-        /// generate and return the proper HTML for this symbol
-        /// </summary>
-        public Token ProcessSymbolUsage(SyntaxToken token, ISymbol symbol)
-        {
-            string fullName = symbol.ToString();
-            string value = token.ToString();
-            string type = string.Empty;
-            int lineNumber = token.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
             if (symbol is INamedTypeSymbol)
             {
                 type = VisualBasicTokenTypes.TYPE;
@@ -164,14 +139,20 @@ namespace SourceBrowser.Generator.DocumentWalkers
             {
                 type = VisualBasicTokenTypes.IDENTIFIER;
             }
-            
+
+            //Do not allow us to search locals
+            if (symbol.Kind == SymbolKind.Local || symbol.Kind == SymbolKind.Parameter)
+            {
+                isSearchable = false;
+            }
+
             var tokenModel = new Token(this.DocumentModel, fullName, value, type, lineNumber);
 
             //If we can find the declaration, we'll link it ourselves
             if (symbol.DeclaringSyntaxReferences.Any()
                 && !(symbol is INamespaceSymbol))
             {
-                var link = new SymbolLink(referencedSymbolName: symbol.ToString());
+                var link = new SymbolLink(referencedSymbolName: fullName);
                 tokenModel = tokenModel.WithLink(link);
             }
             //Otherwise, we try to link to the .Net Reference source
@@ -185,28 +166,34 @@ namespace SourceBrowser.Generator.DocumentWalkers
             return tokenModel;
         }
 
+        private string GetSymbolName(ISymbol symbol)
+        {
+            if (symbol.Kind == SymbolKind.Parameter || symbol.Kind == SymbolKind.Local)
+            {
+                var containingName = symbol.ContainingSymbol.ToString();
+                var name = containingName + "::" + symbol.Name;
+                return name;
+            }
+            else
+            {
+                return symbol.ToString();
+            }
+        }
+
         public Token ProcessIdentifier(SyntaxToken token)
         {
             //Check if this token is part of a declaration
-            var parentSymbol = _model.GetDeclaredSymbol(token.Parent);
-            if (parentSymbol != null)
+            bool isDeclaration = false;
+            if (_model.GetDeclaredSymbol(token.Parent) != null)
             {
-                if (parentSymbol.Kind == SymbolKind.Parameter)
-                {
-                    parentSymbol = parentSymbol.ContainingSymbol;
-                }
-                return ProcessDeclarationToken(token, parentSymbol);
+                isDeclaration = true;
             }
-
-            //Find the symbol this token references
-            var symbol = _model.GetSymbolInfo(token.Parent).Symbol;
+            var startPosition = token.GetLocation().SourceSpan.Start;
+            //Note: We're using the SymbolFinder as it correctly resolves 
+            var symbol = SymbolFinder.FindSymbolAtPosition(_model, startPosition, _document.Project.Solution.Workspace);
             if (symbol != null)
             {
-                if (symbol.Kind == SymbolKind.Parameter)
-                {
-                    symbol = symbol.ContainingSymbol;
-                }
-                return ProcessSymbolUsage(token, symbol);
+                return ProcessSymbolUsage(token, symbol, isDeclaration);
             }
 
             //Otherwise it references something we don't

--- a/src/SourceBrowser.Generator/Model/CSharp/CSharpDelimiters.cs
+++ b/src/SourceBrowser.Generator/Model/CSharp/CSharpDelimiters.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SourceBrowser.Generator.Model.CSharp
+{
+    /// <summary>
+    /// Fully qualified names do not contain enough information to differentiate
+    /// between some symbols. Occasionally we must extend C#'s fully qualified names
+    /// to refer to certain symbols.
+    /// 
+    /// Examples: Local variables, parameters, static constructors etc.
+    /// </summary>
+    public static class CSharpDelimiters
+    {
+        public const string LOCAL_VARIABLE = "::";
+        public const string PARAMETER = "::";
+    }
+}

--- a/src/SourceBrowser.Generator/Model/Token.cs
+++ b/src/SourceBrowser.Generator/Model/Token.cs
@@ -24,9 +24,11 @@ namespace SourceBrowser.Generator.Model
 
         public bool IsDeclaration { get; }
 
+        public bool IsSearchable { get; }
+
         public DocumentModel Document { get; }
 
-        public Token(DocumentModel document, string fullName, string value, string type, int lineNumber, bool isDeclaration = false)
+        public Token(DocumentModel document, string fullName, string value, string type, int lineNumber, bool isDeclaration = false, bool isSearchable = false)
         {
             Document = document;
             FullName = fullName;
@@ -34,9 +36,11 @@ namespace SourceBrowser.Generator.Model
             Type = type;
             LineNumber = lineNumber;
             IsDeclaration = isDeclaration;
+            IsSearchable = isSearchable;
         }
 
-        private Token(Token oldToken, ILink link) : this(oldToken.Document, oldToken.FullName, oldToken.Value, oldToken.Type, oldToken.LineNumber, oldToken.IsDeclaration)
+        private Token(Token oldToken, ILink link) :
+            this(oldToken.Document, oldToken.FullName, oldToken.Value, oldToken.Type, oldToken.LineNumber, oldToken.IsDeclaration, oldToken.IsSearchable)
         {
             Link = link;
             LeadingTrivia = oldToken.LeadingTrivia;
@@ -44,7 +48,7 @@ namespace SourceBrowser.Generator.Model
         }
 
         private Token(Token oldToken, ICollection<Trivia> leading, ICollection<Trivia> trailing) :
-            this(oldToken.Document, oldToken.FullName, oldToken.Value, oldToken.Type, oldToken.LineNumber, oldToken.IsDeclaration)
+            this(oldToken.Document, oldToken.FullName, oldToken.Value, oldToken.Type, oldToken.LineNumber, oldToken.IsDeclaration, oldToken.IsSearchable)
         {
             Link = oldToken.Link;
             LeadingTrivia = leading;

--- a/src/SourceBrowser.Generator/Model/VisualBasic/VBDelimiters.cs
+++ b/src/SourceBrowser.Generator/Model/VisualBasic/VBDelimiters.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SourceBrowser.Generator.Model.VisualBasic
+{
+    /// <summary>
+    /// Fully qualified names do not contain enough information to differentiate
+    /// between some symbols. Occasionally we must extend VB's fully qualified names
+    /// to refer to certain symbols.
+    /// 
+    /// Examples: Local variables, parameters, static constructors etc.
+    /// </summary>
+    public static class VBDelimiters
+    {
+        public const string LOCAL_VARIABLE = "::";
+        public const string PARAMETER = "::";
+    }
+    
+}

--- a/src/SourceBrowser.Generator/SourceBrowser.Generator.csproj
+++ b/src/SourceBrowser.Generator/SourceBrowser.Generator.csproj
@@ -92,6 +92,8 @@
     <Compile Include="DocumentWalkers\CSWalker.cs" />
     <Compile Include="Extensions\SymbolExtensions.cs" />
     <Compile Include="Hacks\DependencyHacks.cs" />
+    <Compile Include="Model\CSharp\CSharpDelimiters.cs" />
+    <Compile Include="Model\VisualBasic\VBDelimiters.cs" />
     <Compile Include="Model\VisualBasic\VisualBasicTokenTypes.cs" />
     <Compile Include="Model\CSharp\CSharpTokenTypes.cs" />
     <Compile Include="Model\DocumentModel.cs" />

--- a/src/SourceBrowser.Generator/Transformers/SearchIndexTransformer.cs
+++ b/src/SourceBrowser.Generator/Transformers/SearchIndexTransformer.cs
@@ -23,7 +23,7 @@ namespace SourceBrowser.Generator.Transformers
         protected override void VisitDocument(DocumentModel documentModel)
         {
             var documentId = Path.Combine(_username, _repository, documentModel.RelativePath);
-            var declarations = documentModel.Tokens.Where(n => n.IsDeclaration);
+            var declarations = documentModel.Tokens.Where(n => n.IsDeclaration && n.IsSearchable);
 
             foreach(var declaration in declarations)
             {


### PR DESCRIPTION
This fixes #63 as well as some undocumented bugs with parameters and local variables:

 - Local variable's fully qualified names were being set to their simple name. This meant that using variables both named `data` in different functions would cause one definition to incorrectly link to the other.

- Parameters were linking to the method itself instead of the parameter inside of the method.

- Search was returning local variables and parameters.

In order to differentiate between different local variables, I append a delimeter (::) and the simple name of the variable to the function or property in which they are contained.

Consider the following:

    namespace MyNamespace
    {
        class MyClass 
        {
            void MyMethod() { int myVariable = 4; }
        }
    }

The fully qualified name of `myVariable` is now `MyNamespace.MyClass.MyMethod::myVariable`. I believe this should work for C# but I'm less familiar with naming rules in VB .Net.

I'll be using a similar approach (but a different delimiter) for #64. 