### PR TITLE
Validate repository. 

### DIFF
--- a/src/SourceBrowser.Site/Controllers/BrowseController.cs
+++ b/src/SourceBrowser.Site/Controllers/BrowseController.cs
@@ -34,6 +34,12 @@
                 return this.View("LookupError");
             }
 
+            if(!BrowserRepository.RepositoryExists(username, repository))
+            {
+                ViewBag.ErrorMessage = "Specified repository could not be found";
+                return this.View("LookupError");
+            }
+
             ViewBag.TreeView = loadTreeView(username, repository);
             var viewModel = BrowserRepository.SetUpSolutionStructure(username, repository, "");
             return View("LookupFolder", "_BrowseLayout", viewModel);

--- a/src/SourceBrowser.Site/Controllers/BrowseController.cs
+++ b/src/SourceBrowser.Site/Controllers/BrowseController.cs
@@ -34,7 +34,7 @@
                 return this.View("LookupError");
             }
 
-            if(!BrowserRepository.RepositoryExists(username, repository))
+            if(!BrowserRepository.PathExists(username, repository))
             {
                 ViewBag.ErrorMessage = "Specified repository could not be found";
                 return this.View("LookupError");
@@ -52,6 +52,12 @@
                 return this.View("LookupError");
             }
 
+            if (!BrowserRepository.PathExists(username, repository, path))
+            {
+                ViewBag.ErrorMessage = "Specified folder could not be found";
+                return this.View("LookupError");
+            }
+
             ViewBag.TreeView = loadTreeView(username, repository);
             var viewModel = BrowserRepository.SetUpSolutionStructure(username, repository, path);
             return View("LookupFolder", "_BrowseLayout", viewModel);
@@ -64,6 +70,11 @@
                 return View("LookupError");
             }
 
+            if (!BrowserRepository.FileExists(username, repository, path))
+            {
+                ViewBag.ErrorMessage = "Specified file could not be found";
+                return this.View("LookupError");
+            }
             var rawHtml = BrowserRepository.GetDocumentHtml(username, repository, path);
 
             ViewBag.TreeView = loadTreeView(username, repository);

--- a/src/SourceBrowser.Site/Repositories/BrowserRepository.cs
+++ b/src/SourceBrowser.Site/Repositories/BrowserRepository.cs
@@ -32,6 +32,13 @@
             }
         }
 
+        internal static bool RepositoryExists(string username, string repository)
+        {
+            var fullPath = Path.Combine(StaticHtmlAbsolutePath, username, repository);
+            return Directory.Exists(fullPath);
+        }
+
+
         /// <summary>
         /// Returns a list of all Github users on file.
         /// </summary>

--- a/src/SourceBrowser.Site/Repositories/BrowserRepository.cs
+++ b/src/SourceBrowser.Site/Repositories/BrowserRepository.cs
@@ -44,10 +44,6 @@
             return File.Exists(fullPath);
         }
 
-
-
-
-
         /// <summary>
         /// Returns a list of all Github users on file.
         /// </summary>
@@ -73,7 +69,7 @@
             return users;
         }
 
-             /// <summary>
+        /// <summary>
         /// Returns a structure containing information on user's github repositories available at Source Browser.
         /// If the structure does not exist, creates it.
         /// </summary>
@@ -278,9 +274,6 @@
             directories = new List<string>(directoryPaths);
             return directories;
         }
-
-
-                                                                                                                        
 
         private static string CreatePath(string part1, string part2 = null, string part3 = null, string part4 = null)
         {

--- a/src/SourceBrowser.Site/Repositories/BrowserRepository.cs
+++ b/src/SourceBrowser.Site/Repositories/BrowserRepository.cs
@@ -32,11 +32,20 @@
             }
         }
 
-        internal static bool RepositoryExists(string username, string repository)
+        internal static bool PathExists(string username, string repository = "", string path = "")
         {
-            var fullPath = Path.Combine(StaticHtmlAbsolutePath, username, repository);
+            var fullPath = Path.Combine(StaticHtmlAbsolutePath, username, repository, path);
             return Directory.Exists(fullPath);
         }
+
+        internal static bool FileExists(string username, string repository, string path)
+        {
+            var fullPath = Path.Combine(StaticHtmlAbsolutePath, username, repository, path);
+            return File.Exists(fullPath);
+        }
+
+
+
 
 
         /// <summary>
@@ -64,7 +73,7 @@
             return users;
         }
 
-        /// <summary>
+             /// <summary>
         /// Returns a structure containing information on user's github repositories available at Source Browser.
         /// If the structure does not exist, creates it.
         /// </summary>

--- a/src/SourceBrowser.Site/Views/Browse/LookupError.cshtml
+++ b/src/SourceBrowser.Site/Views/Browse/LookupError.cshtml
@@ -7,5 +7,10 @@
 <div style="margin:65px 0px 65px 0px" class="text-center">
     <h2>There was and error retrieving this project</h2>
     <h4>Please ensure the URL you're using is correct.</h4>
+    @if(ViewBag.ErrorMessage != null)
+    {
+        <br/>
+        <h4>@ViewBag.ErrorMessage</h4>
+    }
 </div>
 


### PR DESCRIPTION
Similar to #45, we needed to better handle invalid paths for repositories, folders and files.

This only displays a very simple error message to the user, but it's better than dumping a stack trace to the user.