### PR TITLE
Closes #69: Sandboxes MSBuild

### DIFF
--- a/src/SourceBrowser.Generator/SolutionAnalyzer.cs
+++ b/src/SourceBrowser.Generator/SolutionAnalyzer.cs
@@ -62,11 +62,10 @@ namespace SourceBrowser.Generator
             }
         }
 
-        public WorkspaceModel BuildWorkspaceModel(string rootPath)
+        public WorkspaceModel BuildWorkspaceModel(string repositoryRootPath)
         {
-            var containingPath = Directory.GetParent(_solution.FilePath).FullName;
             var solutionName = Path.GetFileName(_solution.FilePath);
-            WorkspaceModel workspaceModel = new WorkspaceModel(solutionName, rootPath);
+            WorkspaceModel workspaceModel = new WorkspaceModel(solutionName, repositoryRootPath);
             //Build document model for every file.
             foreach (var doc in _solution.Projects.SelectMany(n => n.Documents))
             {

--- a/src/SourceBrowser.Site/LowPrivilegeUser.config
+++ b/src/SourceBrowser.Site/LowPrivilegeUser.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<appSettings>
+  <add key="safeUserName" value="" />
+  <add key="safePassword" value="" />
+</appSettings>

--- a/src/SourceBrowser.Site/Repositories/UploadRepository.cs
+++ b/src/SourceBrowser.Site/Repositories/UploadRepository.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+using System.Security.Permissions;
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.ConstrainedExecution;
+using System.Security;
+using System.IO;
+using System.Configuration;
+
+namespace SourceBrowser.Site.Repositories
+{
+    public class UploadRepository
+    {
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern bool LogonUser(String lpszUsername, String lpszDomain, String lpszPassword, int dwLogonType, int dwLogonProvider, out SafeTokenHandle phToken);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        private extern static bool CloseHandle(IntPtr handle);
+
+        internal static Generator.Model.WorkspaceModel ProcessSolution(string solutionPath, string repoRootPath)
+        {
+            SafeTokenHandle safeTokenHandle;
+            string safeUserName = ConfigurationManager.AppSettings["safeUserName"];
+            string safeUserPassword = ConfigurationManager.AppSettings["safePassword"];
+
+            // When testing, give full trust to the developer's machine
+            if (String.IsNullOrEmpty(safeUserName))
+            {
+                var sourceGenerator = new Generator.SolutionAnalayzer(solutionPath);
+                var workspaceModel = sourceGenerator.BuildWorkspaceModel(repoRootPath);
+                return workspaceModel;
+            }
+            // Otherwise, use impersonation to build the solution as user with low privileges.
+            // See http://msdn.microsoft.com/en-us/library/vstudio/w070t6ka.aspx
+
+            const int LOGON32_PROVIDER_DEFAULT = 0;
+            //This parameter causes LogonUser to create a primary token. 
+            const int LOGON32_LOGON_INTERACTIVE = 2;
+
+            // Call LogonUser to obtain a handle to an access token. 
+            bool returnValue = LogonUser(safeUserName, null, safeUserPassword,
+                LOGON32_LOGON_INTERACTIVE, LOGON32_PROVIDER_DEFAULT,
+                out safeTokenHandle);
+
+            if (false == returnValue)
+            {
+                int ret = Marshal.GetLastWin32Error();
+                throw new ApplicationException(String.Format("LogonUser failed with error code : {0}", ret));
+            }
+            using (safeTokenHandle)
+            {
+                // Use the token handle returned by LogonUser. 
+                using (WindowsImpersonationContext impersonatedUser = WindowsIdentity.Impersonate(safeTokenHandle.DangerousGetHandle()))
+                {
+                    var sourceGenerator = new Generator.SolutionAnalayzer(solutionPath);
+                    var workspaceModel = sourceGenerator.BuildWorkspaceModel(repoRootPath);
+                    return workspaceModel;
+                }
+                // Releasing the context object stops the impersonation 
+            }
+        }
+    }
+
+    sealed class SafeTokenHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        private SafeTokenHandle()
+            : base(true)
+        {
+        }
+
+        [DllImport("kernel32.dll")]
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        [SuppressUnmanagedCodeSecurity]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CloseHandle(IntPtr handle);
+
+        protected override bool ReleaseHandle()
+        {
+            return CloseHandle(handle);
+        }
+    }
+}

--- a/src/SourceBrowser.Site/SourceBrowser.Site.csproj
+++ b/src/SourceBrowser.Site/SourceBrowser.Site.csproj
@@ -249,6 +249,7 @@
     <Compile Include="Models\SourceFolderViewModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Repositories\BrowserRepository.cs" />
+    <Compile Include="Repositories\UploadRepository.cs" />
     <Compile Include="Startup.cs" />
     <Compile Include="Utilities\Serialization.cs" />
   </ItemGroup>
@@ -431,6 +432,7 @@
     <Content Include="Scripts\history.js\history.js" />
     <Content Include="Scripts\history.js\json2.js" />
     <Content Include="Scripts\jquery-2.1.1.min.map" />
+    <Content Include="LowPrivilegeUser.config" />
     <None Include="Scripts\jquery.validate-vsdoc.js" />
     <None Include="Scripts\jquery-2.1.1.intellisense.js" />
     <Content Include="Scripts\jquery-2.1.1.js" />

--- a/src/SourceBrowser.Site/SourceBrowser.Site.csproj
+++ b/src/SourceBrowser.Site/SourceBrowser.Site.csproj
@@ -432,7 +432,9 @@
     <Content Include="Scripts\history.js\history.js" />
     <Content Include="Scripts\history.js\json2.js" />
     <Content Include="Scripts\jquery-2.1.1.min.map" />
-    <Content Include="LowPrivilegeUser.config" />
+    <Content Include="LowPrivilegeUser.config">
+      <SubType>Designer</SubType>
+    </Content>
     <None Include="Scripts\jquery.validate-vsdoc.js" />
     <None Include="Scripts\jquery-2.1.1.intellisense.js" />
     <Content Include="Scripts\jquery-2.1.1.js" />

--- a/src/SourceBrowser.Site/Web.config
+++ b/src/SourceBrowser.Site/Web.config
@@ -11,7 +11,7 @@
   <connectionStrings>
     <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\v11.0;AttachDbFilename=|DataDirectory|\aspnet-SourceBrowser.Site-20141108042446.mdf;Initial Catalog=aspnet-SourceBrowser.Site-20141108042446;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
-  <appSettings>
+  <appSettings file="LowPrivilegeUser.config">
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />


### PR DESCRIPTION
Uses ASP.NET impersomation to invoke MSBuild as a user with low privileges:

    using (WindowsImpersonationContext impersonatedUser = WindowsIdentity.Impersonate(safeTokenHandle.DangerousGetHandle()))
    {
        var sourceGenerator = new Generator.SolutionAnalayzer(solutionPath);
        var workspaceModel = sourceGenerator.BuildWorkspaceModel(repoRootPath);
        return workspaceModel;
    }

This requires the server to create a new user without administrative privileges. Username and password for this user are to be saved in **LowPrivilegeUser.config**. 

This user needs near full permissions (sans delete) to the /WorkspaceLogs folder (which must be created, if it doesn't exist):
![sb-security2](https://cloud.githubusercontent.com/assets/1673956/5698847/e53f355e-99cc-11e4-8e4b-13e9a8eded54.png)

In any other folder, the user has standard permissions (to read). No special permissions need to be applied to SB_Files, GithubStaging nor luceneIndex. Alternatively, user may have no read permission to any folder with the exception of GithubStaging (which contains the source to be built):
![sb-security1](https://cloud.githubusercontent.com/assets/1673956/5698848/e53f72e4-99cc-11e4-80d9-b86a3d5206cd.png)