### PR TITLE
Fixing performance issues. Closes #76

### DIFF
--- a/src/SourceBrowser.Generator/Transformers/SearchIndexTransformer.cs
+++ b/src/SourceBrowser.Generator/Transformers/SearchIndexTransformer.cs
@@ -25,12 +25,16 @@ namespace SourceBrowser.Generator.Transformers
             var documentId = Path.Combine(_username, _repository, documentModel.RelativePath);
             var declarations = documentModel.Tokens.Where(n => n.IsDeclaration && n.IsSearchable);
 
-            foreach(var declaration in declarations)
-            {
-                //Add to index
-                var tokenViewModel = new TokenViewModel(_username, _repository, documentId, declaration.FullName, declaration.LineNumber);
-                SearchIndex.AddDeclarationToIndex(tokenViewModel);
-            }
+            var tokenModels = from declaration in declarations
+                              select new TokenViewModel(
+                                  _username,
+                                  _repository,
+                                  documentId,
+                                  declaration.FullName,
+                                  declaration.LineNumber
+                                  );
+
+            SearchIndex.AddDeclarationsToIndex(tokenModels);
 
             base.VisitDocument(documentModel);
         }

--- a/src/SourceBrowser.Search/SearchIndex.cs
+++ b/src/SourceBrowser.Search/SearchIndex.cs
@@ -43,10 +43,10 @@ namespace SourceBrowser.Search
                 File.Delete(lockFilePath);
         }
 
-        static object _lock = new object();
+        static object _luceneWriteLock = new object();
         public static void AddDeclarationsToIndex(IEnumerable<TokenViewModel> tokenModels)
         {
-            lock(_lock)
+            lock(_luceneWriteLock)
             {
                 using (var analyzer = new StandardAnalyzer(Lucene.Net.Util.Version.LUCENE_30))
                 using (var writer = new IndexWriter(_directory, analyzer, IndexWriter.MaxFieldLength.UNLIMITED))
@@ -62,7 +62,7 @@ namespace SourceBrowser.Search
 
         public static void AddDeclarationToIndex(TokenViewModel token)
         {
-            lock(_lock)
+            lock(_luceneWriteLock)
             {
                 using (var analyzer = new StandardAnalyzer(Lucene.Net.Util.Version.LUCENE_30))
                 using (var writer = new IndexWriter(_directory, analyzer, IndexWriter.MaxFieldLength.UNLIMITED))

--- a/src/SourceBrowser.Site/Controllers/UploadController.cs
+++ b/src/SourceBrowser.Site/Controllers/UploadController.cs
@@ -6,6 +6,7 @@
     using SourceBrowser.Generator.Transformers;
     using SourceBrowser.Site.Repositories;
     using System;
+    using System.Linq;
 
     public class UploadController : Controller
     {
@@ -53,7 +54,9 @@
             var repoPath = Path.Combine(organizationPath, retriever.RepoName);
 
             // TODO: Use parallel for.
-            foreach (var solutionPath in solutionPaths)
+            // TODO: Process all solutions.
+            // For now, we're assuming the shallowest and shortest .sln file is the one we're interested in
+            foreach (var solutionPath in solutionPaths.OrderBy(n => n.Length).Take(1))
             {
                 Generator.Model.WorkspaceModel workspaceModel;
                 try
@@ -65,7 +68,7 @@
                     ViewBag.Error = "There was an error processing solution " + Path.GetFileName(solutionPath);
                     return View("Index");
                 }
-                
+
                 //One pass to lookup all declarations
                 var typeTransformer = new TokenLookupTransformer();
                 typeTransformer.Visit(workspaceModel);


### PR DESCRIPTION
Two fixes:

1. We were processing too many solutions for some projects. For example, Newtonsoft.Json has 7. Now we take the solution with the shortest path name, assuming (perhaps incorrectly in some cases) that authors will put their solutions at the shallowest point and that they will have short names. (ie. mySolution.sln vs. mySolution.Portable.sln)

2. Lucene was writing to disk every time a token was added to the index. Now we write only for every single document. This may still be too much, but yielded a massive performance gain as is.