### PR TITLE
Ignore files not found in the repository.

### DIFF
--- a/src/SourceBrowser.Generator/SolutionAnalyzer.cs
+++ b/src/SourceBrowser.Generator/SolutionAnalyzer.cs
@@ -79,6 +79,8 @@ namespace SourceBrowser.Generator
         {
             var syntaxRoot = document.GetSyntaxRootAsync().Result;
             var containingFolder = findDocumentParent(workspaceModel, document);
+            if (containingFolder == null)
+                return;
             var docWalker = WalkerSelector.GetWalker(containingFolder, document, _refsourceLinkProvider);
             docWalker.Visit(syntaxRoot);
             
@@ -92,8 +94,10 @@ namespace SourceBrowser.Generator
             IProjectItem currentNode = workspaceModel;
             var rootPath = workspaceModel.BasePath ;
             var docPath = Directory.GetParent(document.FilePath).FullName;
+            
+            //If we can't find it, it's not located within our repo and we'll ignore it.
             if (!docPath.StartsWith(rootPath))
-                return currentNode;
+                return null;
 
             var relativePath = docPath.Remove(0, rootPath.Length);
 


### PR DESCRIPTION
Fixes #89 

This only existed due to some poor design decisions I made at the start. (We were planning to make everything relative to the .sln file instead of the root of the directory).

So now we can safely say that any file not found within the repository can be ignored. This will get rid of all those auto generated files we were seeing.