### PR TITLE
Update existing repo:

### DIFF
--- a/src/SourceBrowser.Generator/SolutionAnalyzer.cs
+++ b/src/SourceBrowser.Generator/SolutionAnalyzer.cs
@@ -21,13 +21,21 @@ namespace SourceBrowser.Generator
 {
     public class SolutionAnalayzer
     {
+        private static object _sync = new object();
+
         MSBuildWorkspace _workspace;
         Solution _solution;
+        private string _solutionPath;
         private ReferencesourceLinkProvider _refsourceLinkProvider = new ReferencesourceLinkProvider();
 
         public SolutionAnalayzer(string solutionPath)
         {
-            _workspace = MSBuildWorkspace.Create();
+            lock (_sync)
+            {
+                _workspace = MSBuildWorkspace.Create();
+            }
+
+            _solutionPath = solutionPath;
             _workspace.WorkspaceFailed += _workspace_WorkspaceFailed;
             _solution = _workspace.OpenSolutionAsync(solutionPath).Result;
             _refsourceLinkProvider.Init();
@@ -49,7 +57,9 @@ namespace SourceBrowser.Generator
 
                 if (!Directory.Exists(logDirectory))
                     Directory.CreateDirectory(logDirectory);
-                var logPath = logDirectory + "log.txt";
+
+                var logName = Path.GetFileName(_solutionPath);
+                var logPath = $"{logDirectory}{logName}.log.txt";
                 using (var sw = new StreamWriter(logPath))
                 {
                     sw.Write(e);

--- a/src/SourceBrowser.Generator/Transformers/AbstractWorkspaceVisitor.cs
+++ b/src/SourceBrowser.Generator/Transformers/AbstractWorkspaceVisitor.cs
@@ -26,7 +26,7 @@ namespace SourceBrowser.Generator.Transformers
 
         protected virtual void VisitWorkspace(WorkspaceModel workspaceModel)
         {
-            foreach(var child in _workspaceModel.Children)
+            foreach(var child in workspaceModel.Children)
             {
                 VisitProjectItem(child);
             }
@@ -54,7 +54,7 @@ namespace SourceBrowser.Generator.Transformers
 
         protected virtual void VisitFolder(FolderModel folderModel)
         {
-            foreach(var child in folderModel.Children)
+            foreach(var child in folderModel.Children.OrderBy(proj => proj.Name))
             {
                 VisitProjectItem(child);
             }

--- a/src/SourceBrowser.Site/Controllers/BrowseController.cs
+++ b/src/SourceBrowser.Site/Controllers/BrowseController.cs
@@ -111,10 +111,17 @@
             var organizationPath = System.Web.Hosting.HostingEnvironment.MapPath("~/") + "SB_Files\\";
             string treeViewFileName = "treeview.html";
             var treeViewPath = Path.Combine(organizationPath, username, repository, treeViewFileName);
-
-            using (var treeViewFile = new StreamReader(treeViewPath))
+            
+            try
             {
-                return treeViewFile.ReadToEnd();
+                using (var treeViewFile = new StreamReader(treeViewPath))
+                {
+                    return treeViewFile.ReadToEnd();
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                return $"{treeViewFileName} was not found";
             }
         }
 

--- a/src/SourceBrowser.Site/Controllers/UploadController.cs
+++ b/src/SourceBrowser.Site/Controllers/UploadController.cs
@@ -7,6 +7,7 @@
     using SourceBrowser.Site.Repositories;
     using System;
     using System.Linq;
+    using System.Web.Routing;
 
     public class UploadController : Controller
     {
@@ -34,18 +35,23 @@
             // Check if this repo already exists
             if (!BrowserRepository.TryLockRepository(retriever.UserName, retriever.RepoName))
             {
-	            // Repo exists. Redirect the user to that repository.
-	            return Redirect("/Browse/" + retriever.UserName + "/" + retriever.RepoName);
+                // Repo exists. Redirect the user to the Update view
+                // where he can choose if he wants to visit the existing repo or update it.
+                var routeValues = new RouteValueDictionary();
+                routeValues.Add(nameof(githubUrl), githubUrl);
+                return RedirectToAction("Update", routeValues);
             }
+
             // We have locked the repository and marked it as processing.
             // Whenever we return or exit on an exception, we need to unlock this repository
             bool processingSuccessful = false;
             try
             {
-                string repoRootPath = string.Empty;
+                string repoSourceStagingPath = null;
+
                 try
                 {
-                    repoRootPath = retriever.RetrieveProject();
+                    repoSourceStagingPath = retriever.RetrieveProject();
                 }
                 catch (Exception ex)
                 {
@@ -54,59 +60,26 @@
                 }
 
                 // Generate the source browser files for this solution
-                var solutionPaths = GetSolutionPaths(repoRootPath);
-                if (solutionPaths.Length == 0)
+
+                var organizationPath = System.Web.Hosting.HostingEnvironment.MapPath("~/") + "SB_Files\\" + retriever.UserName;
+                var parsedRepoPath = Path.Combine(organizationPath, retriever.RepoName);
+
+                try
+                {
+                    processingSuccessful = UploadRepository.ProcessRepo(retriever, repoSourceStagingPath, parsedRepoPath);
+                }
+                catch (NoSolutionsFoundException)
                 {
                     ViewBag.Error = "No C# solution was found. Ensure that a valid .sln file exists within your repository.";
                     return View("Index");
                 }
-
-                var organizationPath = System.Web.Hosting.HostingEnvironment.MapPath("~/") + "SB_Files\\" + retriever.UserName;
-                var repoPath = Path.Combine(organizationPath, retriever.RepoName);
-
-                // TODO: Use parallel for.
-                // TODO: Process all solutions.
-                // For now, we're assuming the shallowest and shortest .sln file is the one we're interested in
-                foreach (var solutionPath in solutionPaths.OrderBy(n => n.Length).Take(1))
-                {
-                    try
-                    {
-                        var workspaceModel = UploadRepository.ProcessSolution(solutionPath, repoRootPath);
-
-                        //One pass to lookup all declarations
-                        var typeTransformer = new TokenLookupTransformer();
-                        typeTransformer.Visit(workspaceModel);
-                        var tokenLookup = typeTransformer.TokenLookup;
-
-                        //Another pass to generate HTMLs
-                        var htmlTransformer = new HtmlTransformer(tokenLookup, repoPath);
-                        htmlTransformer.Visit(workspaceModel);
-
-                        var searchTransformer = new SearchIndexTransformer(retriever.UserName, retriever.RepoName);
-                        searchTransformer.Visit(workspaceModel);
-
-                        // Generate HTML of the tree view
-                        var treeViewTransformer = new TreeViewTransformer(repoPath, retriever.UserName, retriever.RepoName);
-                        treeViewTransformer.Visit(workspaceModel);
-                    }
-                    catch (Exception ex)
-                    {
-                        // TODO: Log this
-                        ViewBag.Error = "There was an error processing solution " + Path.GetFileName(solutionPath);
-                        return View("Index");
-                    }
-                }
-
-                try
-                {
-                    UploadRepository.SaveReadme(repoPath, retriever.ProvideParsedReadme());
-                }
                 catch (Exception ex)
                 {
-                    // TODO: Log and swallow - readme is not essential.
+                    // TODO: Log this
+                    ViewBag.Error = "There was an error processing solution."/* + Path.GetFileName(solutionPath)*/;
+                    return View("Index");
                 }
-
-                processingSuccessful = true;
+                
                 return Redirect("/Browse/" + retriever.UserName + "/" + retriever.RepoName);
             }
             finally
@@ -123,17 +96,109 @@
         }
 
         /// <summary>
-        /// Simply searches for the solution files and returns their paths.
+        /// This API is used for the updating an existing repo.
+        /// If the request's http method is GET, it will return a View with a link to the existing repo
+        /// and a form that allows the user to force the update.
+        /// If the request's http method is POST, it will delete the existing repo and then
+        /// it will process the github url.
         /// </summary>
-        /// <param name="rootDirectory">
-        /// The root Directory.
-        /// </param>
-        /// <returns>
-        /// The solution paths.
-        /// </returns>
-        private string[] GetSolutionPaths(string rootDirectory)
+        /// <param name="githubUrl">The github url of the repo.</param>
+        [AcceptVerbs(HttpVerbs.Get | HttpVerbs.Post)]
+        public ActionResult Update(string githubUrl)
         {
-            return Directory.GetFiles(rootDirectory, "*.sln", SearchOption.AllDirectories);
+            // If someone navigates to submit directly, just send 'em back to index
+            if (string.IsNullOrWhiteSpace(githubUrl))
+            {
+                return View("Index");
+            }
+
+            var retriever = new GitHubRetriever(githubUrl);
+            if (!retriever.IsValidUrl())
+            {
+                ViewBag.Error = "Make sure that the provided path points to a valid GitHub repository.";
+                return View("Index");
+            }
+
+            // Check if this repo already exists
+            if (!BrowserRepository.PathExists(retriever.UserName, retriever.RepoName))
+            {
+                // Repo doesn't exist.
+                ViewBag.Error = $"The repo \"{githubUrl}\" cannot be updated because it was never submitted.";
+                return View("Index");
+            }
+
+            string currentHttpMethod = HttpContext.Request.HttpMethod.ToUpper();
+
+            if (currentHttpMethod == HttpVerbs.Get.ToString().ToUpper())
+            {
+                ViewBag.BrowseUrl = "/Browse/" + retriever.UserName + "/" + retriever.RepoName;
+                ViewBag.GithubUrl = githubUrl;
+                return View("Update");
+            }
+            else if (currentHttpMethod == HttpVerbs.Post.ToString().ToUpper())
+            {
+                // Remove old files
+                BrowserRepository.RemoveRepository(retriever.UserName, retriever.RepoName);
+                // Create a file that indicates that the upload will begin
+                BrowserRepository.TryLockRepository(retriever.UserName, retriever.RepoName);
+
+                // We have locked the repository and marked it as processing.
+                // Whenever we return or exit on an exception, we need to unlock this repository
+                bool processingSuccessful = false;
+                try
+                {
+                    string repoSourceStagingPath = null;
+
+                    try
+                    {
+                        repoSourceStagingPath = retriever.RetrieveProject();
+                    }
+                    catch (Exception ex)
+                    {
+                        ViewBag.Error = "There was an error downloading this repository.";
+                        return View("Index");
+                    }
+
+                    var organizationPath = System.Web.Hosting.HostingEnvironment.MapPath("~/") + "SB_Files\\" + retriever.UserName;
+                    var parsedRepoPath = Path.Combine(organizationPath, retriever.RepoName);
+
+                    try
+                    {
+                        // Generate the source browser files for this solution
+                        processingSuccessful = UploadRepository.ProcessRepo(retriever, repoSourceStagingPath, parsedRepoPath);
+                    }
+                    catch (NoSolutionsFoundException)
+                    {
+                        ViewBag.Error = "No C# solution was found. Ensure that a valid .sln file exists within your repository.";
+                        return View("Index");
+                    }
+                    catch (Exception ex)
+                    {
+                        // TODO: Log this
+                        ViewBag.Error = "There was an error processing solution."/* + Path.GetFileName(solutionPath)*/;
+                        return View("Index");
+                    }
+                    
+                    return Redirect("/Browse/" + retriever.UserName + "/" + retriever.RepoName);
+                }
+                finally
+                {
+                    if (processingSuccessful)
+                    {
+                        BrowserRepository.UnlockRepository(retriever.UserName, retriever.RepoName);
+                    }
+                    else
+                    {
+                        BrowserRepository.RemoveRepository(retriever.UserName, retriever.RepoName);
+                    }
+                }
+            }
+            else
+            {
+                // The request's http method wasn't valid: back to index 
+                ViewBag.Error = $"Bad request.";
+                return View("Index");
+            }
         }
     }
 }

--- a/src/SourceBrowser.Site/Controllers/UploadController.cs
+++ b/src/SourceBrowser.Site/Controllers/UploadController.cs
@@ -44,7 +44,9 @@
 
             // We have locked the repository and marked it as processing.
             // Whenever we return or exit on an exception, we need to unlock this repository
-            bool processingSuccessful = false;
+
+            ProcessRepoResult result = ProcessRepoResult.Failed;
+
             try
             {
                 string repoSourceStagingPath = null;
@@ -66,12 +68,7 @@
 
                 try
                 {
-                    processingSuccessful = UploadRepository.ProcessRepo(retriever, repoSourceStagingPath, parsedRepoPath);
-                }
-                catch (NoSolutionsFoundException)
-                {
-                    ViewBag.Error = "No C# solution was found. Ensure that a valid .sln file exists within your repository.";
-                    return View("Index");
+                    result = UploadRepository.ProcessRepo(retriever, repoSourceStagingPath, parsedRepoPath);
                 }
                 catch (Exception ex)
                 {
@@ -79,12 +76,18 @@
                     ViewBag.Error = "There was an error processing solution."/* + Path.GetFileName(solutionPath)*/;
                     return View("Index");
                 }
-                
+
+                if (result == ProcessRepoResult.NoSolutionsFound)
+                {
+                    ViewBag.Error = "No C# solution was found. Ensure that a valid .sln file exists within your repository.";
+                    return View("Index");
+                }
+
                 return Redirect("/Browse/" + retriever.UserName + "/" + retriever.RepoName);
             }
             finally
             {
-                if (processingSuccessful)
+                if (result == ProcessRepoResult.Successful)
                 {
                     BrowserRepository.UnlockRepository(retriever.UserName, retriever.RepoName);
                 }
@@ -144,7 +147,9 @@
 
                 // We have locked the repository and marked it as processing.
                 // Whenever we return or exit on an exception, we need to unlock this repository
-                bool processingSuccessful = false;
+
+                ProcessRepoResult result = ProcessRepoResult.Failed;
+
                 try
                 {
                     string repoSourceStagingPath = null;
@@ -165,12 +170,7 @@
                     try
                     {
                         // Generate the source browser files for this solution
-                        processingSuccessful = UploadRepository.ProcessRepo(retriever, repoSourceStagingPath, parsedRepoPath);
-                    }
-                    catch (NoSolutionsFoundException)
-                    {
-                        ViewBag.Error = "No C# solution was found. Ensure that a valid .sln file exists within your repository.";
-                        return View("Index");
+                        result = UploadRepository.ProcessRepo(retriever, repoSourceStagingPath, parsedRepoPath);
                     }
                     catch (Exception ex)
                     {
@@ -178,12 +178,18 @@
                         ViewBag.Error = "There was an error processing solution."/* + Path.GetFileName(solutionPath)*/;
                         return View("Index");
                     }
-                    
+
+                    if (result == ProcessRepoResult.NoSolutionsFound)
+                    {
+                        ViewBag.Error = "No C# solution was found. Ensure that a valid .sln file exists within your repository.";
+                        return View("Index");
+                    }
+
                     return Redirect("/Browse/" + retriever.UserName + "/" + retriever.RepoName);
                 }
                 finally
                 {
-                    if (processingSuccessful)
+                    if (result == ProcessRepoResult.Successful)
                     {
                         BrowserRepository.UnlockRepository(retriever.UserName, retriever.RepoName);
                     }

--- a/src/SourceBrowser.Site/Repositories/BrowserRepository.cs
+++ b/src/SourceBrowser.Site/Repositories/BrowserRepository.cs
@@ -37,13 +37,13 @@
 
         internal static bool TryLockRepository(string userName, string repoName)
         {
-	        string lockFileDirectory = Path.Combine(StaticHtmlAbsolutePath, userName, repoName);
+	        string lockFileDirectory = GetLockFileDirectoryPath(userName, repoName);
             if (Directory.Exists(lockFileDirectory))
             {
                 // The directory already exists, we can't modify this repository.
                 return false;
             }
-            string lockFilePath = Path.Combine(lockFileDirectory, Constants.REPO_LOCK_FILENAME);
+            string lockFilePath = GetLockFilePath(userName, repoName);
             lock (fileOperationLock)
             {
                 if (File.Exists(lockFilePath))
@@ -66,7 +66,7 @@
 
         internal static void UnlockRepository(string userName, string repoName)
         {
-	        string lockFilePath = Path.Combine(StaticHtmlAbsolutePath, userName, repoName, Constants.REPO_LOCK_FILENAME);
+            string lockFilePath = GetLockFilePath(userName, repoName);
             lock (fileOperationLock)
             {
                 if (File.Exists(lockFilePath))
@@ -78,7 +78,7 @@
 
         internal static bool IsRepositoryReady(string userName, string repoName)
         {
-            string lockFilePath = Path.Combine(StaticHtmlAbsolutePath, userName, repoName, Constants.REPO_LOCK_FILENAME);
+            string lockFilePath = GetLockFilePath(userName, repoName);
             lock (fileOperationLock)
             {
                 if (File.Exists(lockFilePath))
@@ -91,7 +91,7 @@
 
         internal static void RemoveRepository(string userName, string repoName)
         {
-            string lockFileDirectory = Path.Combine(StaticHtmlAbsolutePath, userName, repoName);
+            string lockFileDirectory = GetLockFileDirectoryPath(userName, repoName);
             lock (fileOperationLock)
             {
                 if (Directory.Exists(lockFileDirectory))
@@ -111,6 +111,22 @@
         {
             var fullPath = Path.Combine(StaticHtmlAbsolutePath, username, repository, path);
             return File.Exists(fullPath);
+        }
+
+        /// <summary>
+        /// Helper method to retrieve the lock file directory path of the given repo.
+        /// </summary>
+        private static string GetLockFileDirectoryPath(string userName, string repoName)
+        {
+            return Path.Combine(StaticHtmlAbsolutePath, userName, repoName);
+        }
+
+        /// <summary>
+        /// Helper method to retrieve the lock file path of the given repo.
+        /// </summary>
+        private static string GetLockFilePath(string userName, string repoName)
+        {
+            return Path.Combine(GetLockFileDirectoryPath(userName, repoName), Constants.REPO_LOCK_FILENAME);
         }
 
         /// <summary>
@@ -267,7 +283,7 @@
         private static GithubRepoStructure SetUpRepoStructure(string userName, string repoName)
         {
             // Currently unused, might be useful at some point
-            // var repoRoot = Path.Combine(StaticHtmlAbsolutePath, userName, repoName);
+            // var repoRoot = GetLockFileDirectoryPath(userName, repoName);
 
             var repoData = new GithubRepoStructure()
             {

--- a/src/SourceBrowser.Site/SourceBrowser.Site.csproj
+++ b/src/SourceBrowser.Site/SourceBrowser.Site.csproj
@@ -20,6 +20,7 @@
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -501,6 +502,7 @@
     <Content Include="Views\Upload\Index.cshtml" />
     <Content Include="Views\Shared\_BrowseLayout.cshtml" />
     <Content Include="Views\Browse\AwaitLookup.cshtml" />
+    <Content Include="Views\Upload\Update.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />

--- a/src/SourceBrowser.Site/Views/Upload/Update.cshtml
+++ b/src/SourceBrowser.Site/Views/Upload/Update.cshtml
@@ -1,0 +1,26 @@
+﻿@{
+    ViewBag.Title = "Update existing repo";
+}
+
+@Scripts.Render("~/bundles/jquery")
+@Scripts.Render("~/bundles/upload")
+
+<div id="upload-header" class="text-center">
+    <h2>This repo already exists</h2>
+    <h5><a href="@ViewBag.BrowseUrl">@ViewBag.GithubUrl</a></h5>
+    @if (ViewBag.Error != null)
+    {
+        <h5 id="upload-error">@ViewBag.Error</h5>
+    }
+</div>
+
+<form id="upload-form" method="post" action="~/Upload/Update/" class="bs-example bs-example-form" role="form">
+    <div class="input-group input-group-lg" >
+		<input type="hidden" name="githubUrl" value="@ViewBag.GithubUrl">
+        <button class="btn btn-default button large primary" type="submit">Update existing repo</button>
+    </div>
+</form>
+
+<div class="text-center upload-message">
+    Uploading.  Please Wait...
+</div>


### PR DESCRIPTION
When a user submits a repository that already exists, a page is returned where he can choose if he wants to go to the existing source or force the update.

<img width="960" alt="sourcebrowser_update" src="https://cloud.githubusercontent.com/assets/8939890/23833866/7ee84e40-074c-11e7-8730-db96791959dc.PNG">

Added a new action "Update" (and a View) in the UploadController.
Refactored some of the ProcessSolution logic into the UploadRepository class.
As suggested in the comments (by Amadeus Wieczorek), added support for multi-solution repository and parallel solution processing.

(Also proposed in issue #114)